### PR TITLE
Contextual log dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: trusty
 sudo: false
 php:
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     },
     "autoload-dev":{
         "psr-4":{
-            "BEAR\\AppMeta\\": "tests/",
-            "BEAR\\AppMeta\\": "tests/Fake",
+            "BEAR\\AppMeta\\": ["tests/", "tests/Fake"],
             "FakeVendor\\HelloWorld\\": "tests/Fake/fake-app/src"
         }
     },
@@ -22,6 +21,6 @@
     },
     "require-dev": {
         "bear/resource": "~1.0",
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7 || ^6.0"
     }
 }

--- a/src/AppMeta.php
+++ b/src/AppMeta.php
@@ -29,7 +29,10 @@ class AppMeta extends AbstractAppMeta
         if (! file_exists($this->tmpDir) && mkdir($this->tmpDir) && ! is_writable($this->tmpDir)) {
             throw new NotWritableException($this->tmpDir);
         }
-        $this->logDir = $this->appDir . '/var/log';
+        $this->logDir = $this->appDir . '/var/log/' . $context;
+        if (! file_exists($this->logDir) && mkdir($this->logDir) && ! is_writable($this->logDir)) {
+            throw new NotWritableException($this->logDir);
+        }
         $isDevelop = strpos($context, 'prod') === false;
         if ($isDevelop) {
             $this->clearTmpDirectory($this->tmpDir);

--- a/src/AppMeta.php
+++ b/src/AppMeta.php
@@ -60,7 +60,7 @@ class AppMeta extends AbstractAppMeta
          */
         static $done = false;
 
-        if ($done) {
+        if ($done || file_exists($dir . '/.do_not_clear')) {
             return;
         }
         $unlink = function ($path) use (&$unlink) {

--- a/tests/AppMetaTest.php
+++ b/tests/AppMetaTest.php
@@ -2,9 +2,9 @@
 
 namespace BEAR\AppMeta;
 
-use BEAR\AppMeta\Exception\AppNameException;
+use PHPUnit\Framework\TestCase;
 
-class AppMetaTest extends \PHPUnit_Framework_TestCase
+class AppMetaTest extends TestCase
 {
     /**
      * @var AppMeta
@@ -52,9 +52,11 @@ class AppMetaTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expect, $files);
     }
 
+    /**
+     * @expectedException \BEAR\AppMeta\Exception\AppNameException
+     */
     public function testInvalidName()
     {
-        $this->setExpectedException(AppNameException::class);
         new AppMeta('Invalid\Invalid');
     }
 


### PR DESCRIPTION
 * Contextual log dir to avoid write permission conflicts
 * Place `.do_not_clear` in `/tmp/{context}`. Then it prevents directory clear on each execution.