### PR TITLE
Fix Scrutinizer permission issue with sudo

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,8 +8,8 @@ build:
                 override: true
             dependencies:
                 before:
-                    - apt-get update -qq
-                    - apt-get install -y libssl-dev pkg-config
+                    - sudo apt-get update -qq
+                    - sudo apt-get install -y libssl-dev pkg-config
             tests:
                 override:
                     - php-scrutinizer-run


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prefix apt-get update and install commands with sudo in .scrutinizer.yml to fix permission errors