### PR TITLE
Allow optional tmpDir and logDir in Meta constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.11.0] - 2026-07-10
+
+### Added
+- Optional `$tmpDir` and `$logDir` constructor arguments on `Meta` (defaults unchanged: `{appDir}/var/tmp/{context}` and `{appDir}/var/log/{context}`) (#41)
+
+### Changed
+- Centralize directory creation and writability checks in `ensureDir()`
+- Default path segments use `/` (portable on Windows PHP)
 
 ## [1.10.0] - 2025-10-27
 
@@ -33,5 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows path separator issues in tests
 - Add descriptive assert messages for better debugging
 
-[Unreleased]: https://github.com/bearsunday/BEAR.AppMeta/compare/1.10.0...HEAD
+[1.11.0]: https://github.com/bearsunday/BEAR.AppMeta/compare/1.10.0...1.11.0
 [1.10.0]: https://github.com/bearsunday/BEAR.AppMeta/compare/1.9.0...1.10.0

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ $appMeta = new Meta('MyVendor\HelloWorld');
 
 // Access metadata properties
 echo $appMeta->name;    // MyVendor\HelloWorld
-echo $appMeta->appDir;  // /path/to/MyVendor/HelloWorld/src
-echo $appMeta->logDir;  // /path/to/MyVendor/HelloWorld/var/log
-echo $appMeta->tmpDir;  // /path/to/MyVendor/HelloWorld/var/tmp
+echo $appMeta->appDir;  // /path/to/project
+echo $appMeta->logDir;  // /path/to/project/var/log/{context}
+echo $appMeta->tmpDir;  // /path/to/project/var/tmp/{context}
+
+// Optional path overrides (null keeps the defaults above):
+// new Meta($name, $context, $appDir, tmpDir: '/var/tmp/my-app', logDir: '/var/log/my-app');
+// Environment reading belongs to the application, not Meta.
 ```
 
 ### Fetching Resource Metadata

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -14,6 +14,7 @@ use function dirname;
 use function file_exists;
 use function is_dir;
 use function mkdir;
+use function rtrim;
 use function sprintf;
 
 use const DIRECTORY_SEPARATOR;
@@ -22,27 +23,49 @@ use const DIRECTORY_SEPARATOR;
  * @psalm-import-type AppName from Types
  * @psalm-import-type Context from Types
  * @psalm-import-type AppDir from Types
+ * @psalm-import-type TmpDir from Types
+ * @psalm-import-type LogDir from Types
  */
 final class Meta extends AbstractAppMeta
 {
     /**
-     * @param AppName $name    application name      (Vendor\Project)
-     * @param Context $context application context   (prod-hal-app)
-     * @param string  $appDir  application directory
+     * @param AppName     $name    application name      (Vendor\Project)
+     * @param Context     $context application context   (prod-hal-app)
+     * @param string      $appDir  application directory
+     * @param TmpDir|null $tmpDir  writable tmp directory (default: {appDir}/var/tmp/{context})
+     * @param LogDir|null $logDir  log directory (default: {appDir}/var/log/{context})
      */
-    public function __construct(string $name, string $context = 'app', string $appDir = '')
-    {
+    public function __construct(
+        string $name,
+        string $context = 'app',
+        string $appDir = '',
+        string|null $tmpDir = null,
+        string|null $logDir = null,
+    ) {
         $this->name = $name;
-        $this->appDir = $appDir ?: $this->getAppDir($name);
-        $this->tmpDir = $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'tmp' . DIRECTORY_SEPARATOR . $context;
-        if (! file_exists($this->tmpDir) && ! @mkdir($this->tmpDir, 0777, true) && ! is_dir($this->tmpDir)) {
-            throw new NotWritableException($this->tmpDir);
+        $this->appDir = $appDir !== '' ? $appDir : $this->getAppDir($name);
+        $this->tmpDir = $this->ensureDir(
+            $tmpDir ?? $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'tmp' . DIRECTORY_SEPARATOR . $context,
+        );
+        $this->logDir = $this->ensureDir(
+            $logDir ?? $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'log' . DIRECTORY_SEPARATOR . $context,
+        );
+    }
+
+    /**
+     * @param non-empty-string $dir
+     *
+     * @return non-empty-string
+     */
+    private function ensureDir(string $dir): string
+    {
+        $dir = rtrim($dir, '/\\');
+        assert($dir !== '');
+        if (! file_exists($dir) && ! @mkdir($dir, 0777, true) && ! is_dir($dir)) {
+            throw new NotWritableException($dir);
         }
 
-        $this->logDir = $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'log' . DIRECTORY_SEPARATOR . $context;
-        if (! file_exists($this->logDir) && ! @mkdir($this->logDir, 0777, true) && ! is_dir($this->logDir)) {
-            throw new NotWritableException($this->logDir); // @codeCoverageIgnore
-        }
+        return $dir;
     }
 
     /**

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -42,7 +42,6 @@ final class Meta extends AbstractAppMeta
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : $this->getAppDir($name);
-        // PHP accepts '/' on Windows for filesystem APIs (mkdir, file_exists, …).
         $this->tmpDir = $this->ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = $this->ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -17,8 +17,6 @@ use function mkdir;
 use function rtrim;
 use function sprintf;
 
-use const DIRECTORY_SEPARATOR;
-
 /**
  * @psalm-import-type AppName from Types
  * @psalm-import-type Context from Types
@@ -44,12 +42,9 @@ final class Meta extends AbstractAppMeta
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : $this->getAppDir($name);
-        $this->tmpDir = $this->ensureDir(
-            $tmpDir ?? $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'tmp' . DIRECTORY_SEPARATOR . $context,
-        );
-        $this->logDir = $this->ensureDir(
-            $logDir ?? $this->appDir . DIRECTORY_SEPARATOR . 'var' . DIRECTORY_SEPARATOR . 'log' . DIRECTORY_SEPARATOR . $context,
-        );
+        // PHP accepts '/' on Windows for filesystem APIs (mkdir, file_exists, …).
+        $this->tmpDir = $this->ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
+        $this->logDir = $this->ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
     }
 
     /**

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -16,6 +16,8 @@ use function dirname;
 use function file_put_contents;
 use function sort;
 use function str_replace;
+use function sys_get_temp_dir;
+use function uniqid;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -82,6 +84,18 @@ class MetaTest extends TestCase
     {
         new Meta('FakeVendor\HelloWorld', 'test-app');
         $this->assertFileExists($this->normalizePath(__DIR__ . '/Fake/fake-app/var/tmp/test-app/not-cleared.txt'));
+    }
+
+    public function testCustomTmpAndLogDir(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $tmpDir = $base . DIRECTORY_SEPARATOR . 'tmp';
+        $logDir = $base . DIRECTORY_SEPARATOR . 'log';
+        $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $tmpDir, $logDir);
+        $this->assertSame($this->normalizePath($tmpDir), $this->normalizePath($meta->tmpDir));
+        $this->assertSame($this->normalizePath($logDir), $this->normalizePath($meta->logDir));
+        $this->assertDirectoryExists($meta->tmpDir);
+        $this->assertDirectoryExists($meta->logDir);
     }
 
     private function normalizePath(string $path): string


### PR DESCRIPTION
## Summary

- Add optional `$tmpDir` / `$logDir` constructor arguments to `Meta` (BC: existing 3-arg calls unchanged).
- Default remains `{appDir}/var/tmp/{context}` and `{appDir}/var/log/{context}`.
- Centralize mkdir / writability checks in `ensureDir()`.
- Environment reading is intentionally **not** done in Meta; applications resolve paths and pass them in.

## Usage

```php
// defaults
new Meta('MyVendor\Project', 'prod-app', $appDir);

// overrides (resolved paths only)
new Meta('MyVendor\Project', 'prod-app', $appDir, '/var/tmp/my-app', '/var/log/my-app');
```

## Motivation

Writable directories are deploy-dependent. Package compile can share the same Meta via the application injector (`Compiler::fromInjector`). Meta should accept explicit paths without taking on env/bootstrap policy.

## Test plan

- [x] `composer tests` (cs / sa / phpunit)
- [x] Default tmp/log paths still created under `var/`
- [x] Custom tmpDir/logDir are used and created
- [ ] CI green on PHP 8.1+