### PR TITLE
Separate scriptDir from tmpDir and layer given bases by app and context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2026-08-13
+
+### Added
+- `Meta::$scriptDir` — compiled DI script directory, and an optional `$scriptDir` constructor argument (default: `{appDir}/var/tmp/{context}/di`)
+
+### Changed
+- A given `$tmpDir` / `$logDir` / `$scriptDir` is treated as a shared base and layered by app and context (`/tmp` → `/tmp/MyVendor/HelloWorld/prod-app`); 1.11.0 took it verbatim, so two apps or contexts handed one directory answered with each other's DI scripts and cache entries
+- `$scriptDir` does not follow a `$tmpDir` override: compiled scripts are a build output that ships in the deployment artifact, so a cold start on a read-only platform reads them instead of compiling again
+
 ## [1.11.0] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,13 +27,20 @@ use BEAR\AppMeta\Meta;
 $appMeta = new Meta('MyVendor\HelloWorld');
 
 // Access metadata properties
-echo $appMeta->name;    // MyVendor\HelloWorld
-echo $appMeta->appDir;  // /path/to/project
-echo $appMeta->logDir;  // /path/to/project/var/log/{context}
-echo $appMeta->tmpDir;  // /path/to/project/var/tmp/{context}
+echo $appMeta->name;      // MyVendor\HelloWorld
+echo $appMeta->appDir;    // /path/to/project
+echo $appMeta->logDir;    // /path/to/project/var/log/{context}
+echo $appMeta->tmpDir;    // /path/to/project/var/tmp/{context}
+echo $appMeta->scriptDir; // /path/to/project/var/tmp/{context}/di
 
-// Optional path overrides (null keeps the defaults above):
-// new Meta($name, $context, $appDir, tmpDir: '/var/tmp/my-app', logDir: '/var/log/my-app');
+// A read-only deployment where only /tmp is writable (Vercel and the like):
+$appMeta = new Meta('MyVendor\HelloWorld', 'prod-app', tmpDir: '/tmp');
+echo $appMeta->tmpDir;    // /tmp/MyVendor/HelloWorld/prod-app
+echo $appMeta->scriptDir; // /path/to/project/var/tmp/prod-app/di
+
+// A given base is shared - a deploy hands one directory and knows neither app nor context - so
+// both are layered under it. Compiled scripts are a build output and stay under appDir: they ship
+// in the artifact, so a cold start reads them instead of compiling again.
 // Environment reading belongs to the application, not Meta.
 ```
 

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -25,6 +25,7 @@ use const DIRECTORY_SEPARATOR;
  * @psalm-import-type AppName from Types
  * @psalm-import-type AppDir from Types
  * @psalm-import-type TmpDir from Types
+ * @psalm-import-type ScriptDir from Types
  * @psalm-import-type LogDir from Types
  * @psalm-import-type UriPath from Types
  * @psalm-import-type FilePath from Types
@@ -44,6 +45,9 @@ abstract class AbstractAppMeta
 
     /** @var TmpDir */
     public string $tmpDir;
+
+    /** @var ScriptDir */
+    public string $scriptDir;
 
     /** @var LogDir */
     public string $logDir;

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -16,6 +16,8 @@ use function is_dir;
 use function mkdir;
 use function rtrim;
 use function sprintf;
+use function str_ends_with;
+use function str_replace;
 
 /**
  * @psalm-import-type AppName from Types
@@ -23,15 +25,17 @@ use function sprintf;
  * @psalm-import-type AppDir from Types
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
+ * @psalm-import-type ScriptDir from Types
  */
 final class Meta extends AbstractAppMeta
 {
     /**
-     * @param AppName     $name    application name      (Vendor\Project)
-     * @param Context     $context application context   (prod-hal-app)
-     * @param string      $appDir  application directory
-     * @param TmpDir|null $tmpDir  writable tmp directory (default: {appDir}/var/tmp/{context})
-     * @param LogDir|null $logDir  log directory (default: {appDir}/var/log/{context})
+     * @param AppName        $name      application name      (Vendor\Project)
+     * @param Context        $context   application context   (prod-hal-app)
+     * @param string         $appDir    application directory
+     * @param TmpDir|null    $tmpDir    writable base for scratch (default: {appDir}/var/tmp/{context})
+     * @param LogDir|null    $logDir    log base (default: {appDir}/var/log/{context})
+     * @param ScriptDir|null $scriptDir compiled DI script base (default: {appDir}/var/tmp/{context}/di)
      */
     public function __construct(
         string $name,
@@ -39,11 +43,33 @@ final class Meta extends AbstractAppMeta
         string $appDir = '',
         string|null $tmpDir = null,
         string|null $logDir = null,
+        string|null $scriptDir = null,
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : $this->getAppDir($name);
-        $this->tmpDir = $this->ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
-        $this->logDir = $this->ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
+        $this->tmpDir = $this->ensureDir($this->resolve($tmpDir, $this->appDir . '/var/tmp/' . $context, $context));
+        $this->logDir = $this->ensureDir($this->resolve($logDir, $this->appDir . '/var/log/' . $context, $context));
+        $this->scriptDir = $this->ensureDir($this->resolve($scriptDir, $this->appDir . '/var/tmp/' . $context . '/di', $context));
+    }
+
+    /**
+     * Layer a given base by app and context, so one directory can serve several. Idempotent.
+     *
+     * @param non-empty-string $default
+     * @param Context          $context
+     *
+     * @return non-empty-string
+     */
+    private function resolve(string|null $base, string $default, string $context): string
+    {
+        if ($base === null) {
+            return $default;
+        }
+
+        $base = rtrim($base, '/\\');
+        $suffix = '/' . str_replace('\\', '/', $this->name) . '/' . $context;
+
+        return str_ends_with($base, $suffix) ? $base : $base . $suffix;
     }
 
     /**

--- a/src/Types.php
+++ b/src/Types.php
@@ -14,6 +14,7 @@ namespace BEAR\AppMeta;
  * @psalm-type Context = non-empty-string
  * @psalm-type AppDir = non-empty-string
  * @psalm-type TmpDir = non-empty-string
+ * @psalm-type ScriptDir = non-empty-string
  * @psalm-type LogDir = non-empty-string
  * @psalm-type UriPath = non-empty-string
  * @psalm-type FilePath = non-empty-string

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -86,16 +86,69 @@ class MetaTest extends TestCase
         $this->assertFileExists($this->normalizePath(__DIR__ . '/Fake/fake-app/var/tmp/test-app/not-cleared.txt'));
     }
 
-    public function testCustomTmpAndLogDir(): void
+    /**
+     * A given base is shared: a deploy hands one directory and knows neither app nor context, so
+     * both are layered under it - two apps or contexts in one directory would silently answer with
+     * each other's DI scripts and cache entries.
+     */
+    public function testCustomTmpAndLogDirAreLayeredByAppAndContext(): void
     {
         $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
         $tmpDir = $base . DIRECTORY_SEPARATOR . 'tmp';
         $logDir = $base . DIRECTORY_SEPARATOR . 'log';
         $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $tmpDir, $logDir);
-        $this->assertSame($this->normalizePath($tmpDir), $this->normalizePath($meta->tmpDir));
-        $this->assertSame($this->normalizePath($logDir), $this->normalizePath($meta->logDir));
+        $this->assertSame($this->normalizePath($tmpDir . '/FakeVendor/HelloWorld/prod-app'), $this->normalizePath($meta->tmpDir));
+        $this->assertSame($this->normalizePath($logDir . '/FakeVendor/HelloWorld/prod-app'), $this->normalizePath($meta->logDir));
         $this->assertDirectoryExists($meta->tmpDir);
         $this->assertDirectoryExists($meta->logDir);
+    }
+
+    /** The namespace separator maps to a directory separator, so distinct apps never share a directory. */
+    public function testLayeredPathKeepsUnderscoresDistinctFromNamespaces(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $appDir = __DIR__ . '/Fake/fake-app';
+        $underscore = new Meta('My_Vendor\App', 'prod-app', $appDir, $base);
+        $namespaced = new Meta('My\Vendor_App', 'prod-app', $appDir, $base);
+        $this->assertNotSame($namespaced->tmpDir, $underscore->tmpDir);
+        $this->assertSame($this->normalizePath($base . '/My_Vendor/App/prod-app'), $this->normalizePath($underscore->tmpDir));
+        $this->assertSame($this->normalizePath($base . '/My/Vendor_App/prod-app'), $this->normalizePath($namespaced->tmpDir));
+    }
+
+    public function testScriptDirDefaultsUnderTmpDirOfTheAppDir(): void
+    {
+        $meta = new Meta('FakeVendor\HelloWorld', 'prod-app');
+        $this->assertSame($this->normalizePath($meta->appDir . '/var/tmp/prod-app/di'), $this->normalizePath($meta->scriptDir));
+        $this->assertDirectoryExists($meta->scriptDir);
+    }
+
+    /**
+     * Compiled scripts are a build output: they ship in the deployment artifact and are read at
+     * runtime, where the artifact may be read-only. Moving tmpDir to a writable volume must not
+     * drag them along, or every cold start recompiles what the build already produced.
+     */
+    public function testScriptDirDoesNotFollowATmpDirOverride(): void
+    {
+        $tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $tmpDir);
+        $this->assertSame($this->normalizePath($meta->appDir . '/var/tmp/prod-app/di'), $this->normalizePath($meta->scriptDir));
+        $this->assertStringStartsWith($this->normalizePath($tmpDir), $this->normalizePath($meta->tmpDir));
+    }
+
+    /** A compile delegated to a child process rebuilds Meta from the resolved dirs; layering twice would split them. */
+    public function testLayeringIsIdempotent(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $first = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $base);
+        $rebuilt = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $first->tmpDir);
+        $this->assertSame($first->tmpDir, $rebuilt->tmpDir);
+    }
+
+    public function testScriptDirOverrideIsLayeredToo(): void
+    {
+        $scriptDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', '', null, null, $scriptDir);
+        $this->assertSame($this->normalizePath($scriptDir . '/FakeVendor/HelloWorld/prod-app'), $this->normalizePath($meta->scriptDir));
     }
 
     private function normalizePath(string $path): string


### PR DESCRIPTION
1.11.0 took a given `$tmpDir` / `$logDir` verbatim. Two consequences, both silent, measured on BEAR.Hello.

**A shared base mixes apps and contexts.** Script file names are dependency hashes and local cache keys are resource URIs, so two contexts pointed at one directory overwrite each other: a `prod-app` web request booted the other context's container and got `CliRouter` injected. A given base is now layered as `{base}/{name}/{context}`, using `/` for the namespace separator so `My_Vendor\App` and `My\Vendor_App` stay apart. Idempotent.

**Compiled scripts followed the writable directory.** `/tmp` is empty on every new instance, so `tmpDir: '/tmp'` moved the build output out of the artifact and each cold start recompiled: 0.38s against 0.018s. `scriptDir` is now its own property, anchored under `appDir`.

Defaults unchanged. `16 tests`, phpcs / phpstan / psalm clean. Pairs with bearsunday/BEAR.Package#491.