### PR TITLE
Place an application under a writable base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Meta::create($name, $context, $appDir, $writeDir)` places an application under `{writeDir}/{Vendor}/{Project}/{context}`, or its own `var/` when null
 - `$writeDir` on `AbstractAppMeta`: the base an application writes under, carried rather than derived
 - `Meta::appDir($name)` resolves an application directory from its name
+- `Meta::create()` refuses a write directory the current directory would resolve, with `WriteDirNotAbsoluteException`
 
 ## [1.11.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `Meta::create($name, $context, $appDir, $writeDir)` places an application under `{writeDir}/{Vendor}/{Project}/{context}`, or its own `var/` when null
+- `$writeDir` on `AbstractAppMeta`: the base an application writes under, carried rather than derived
+- `Meta::appDir($name)` resolves an application directory from its name
+
 ## [1.11.0] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ echo $appMeta->tmpDir;  // /path/to/project/var/tmp/{context}
 
 // An application that may not write in its own directory - a read-only image, an archive -
 // is placed under a writable base, and carries it:
-$appMeta = Meta::create('MyVendor\HelloWorld', 'prod-app', $appDir, '/mnt/write');
+$appMeta = Meta::create('MyVendor\HelloWorld', 'prod-app', $appMeta->appDir, '/mnt/write');
 echo $appMeta->tmpDir;    // /mnt/write/MyVendor/HelloWorld/prod-app/tmp
 echo $appMeta->writeDir;  // /mnt/write
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ echo $appMeta->tmpDir;  // /path/to/project/var/tmp/{context}
 
 // Optional path overrides (null keeps the defaults above):
 // new Meta($name, $context, $appDir, tmpDir: '/var/tmp/my-app', logDir: '/var/log/my-app');
+
+// An application that may not write in its own directory - a read-only image, an archive -
+// is placed under a writable base, and carries it:
+$appMeta = Meta::create('MyVendor\HelloWorld', 'prod-app', $appDir, '/mnt/write');
+echo $appMeta->tmpDir;    // /mnt/write/MyVendor/HelloWorld/prod-app/tmp
+echo $appMeta->writeDir;  // /mnt/write
+
 // Environment reading belongs to the application, not Meta.
 ```
 

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -50,7 +50,7 @@ abstract class AbstractAppMeta
     public string $logDir;
 
     /**
-     * The base directory this application writes under, null when it writes in its own var/
+     * The base directory this application was placed under, null when it was not placed under one
      *
      * @var WriteDir|null
      */

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -26,6 +26,7 @@ use const DIRECTORY_SEPARATOR;
  * @psalm-import-type AppDir from Types
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
+ * @psalm-import-type WriteDir from Types
  * @psalm-import-type UriPath from Types
  * @psalm-import-type FilePath from Types
  * @psalm-import-type Scheme from Types
@@ -47,6 +48,13 @@ abstract class AbstractAppMeta
 
     /** @var LogDir */
     public string $logDir;
+
+    /**
+     * The base directory this application writes under, null when it writes in its own var/
+     *
+     * @var WriteDir|null
+     */
+    public string|null $writeDir = null;
 
     /** @return Generator<array{0: class-string<ResourceObject>, 1: FilePath}> */
     public function getResourceListGenerator(): Generator

--- a/src/Exception/WriteDirNotAbsoluteException.php
+++ b/src/Exception/WriteDirNotAbsoluteException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\AppMeta\Exception;
+
+use LogicException;
+
+final class WriteDirNotAbsoluteException extends LogicException
+{
+}

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -6,6 +6,7 @@ namespace BEAR\AppMeta;
 
 use BEAR\AppMeta\Exception\AppNameException;
 use BEAR\AppMeta\Exception\NotWritableException;
+use BEAR\AppMeta\Exception\WriteDirNotAbsoluteException;
 use ReflectionClass;
 
 use function assert;
@@ -14,6 +15,7 @@ use function dirname;
 use function file_exists;
 use function is_dir;
 use function mkdir;
+use function preg_match;
 use function rtrim;
 use function sprintf;
 use function str_replace;
@@ -57,11 +59,18 @@ final class Meta extends AbstractAppMeta
      * @param Context       $context
      * @param AppDir        $appDir
      * @param WriteDir|null $writeDir absolute base outside the application directory
+     *
+     * @throws WriteDirNotAbsoluteException
      */
     public static function create(string $name, string $context, string $appDir, string|null $writeDir): self
     {
         if ($writeDir === null) {
             return new self($name, $context, $appDir);
+        }
+
+        // A base the current directory resolves lands somewhere else on the next run
+        if (! preg_match('#^(/|\\\\\\\\|[A-Za-z]:[/\\\\]|[A-Za-z][A-Za-z0-9+.\-]*://)#', $writeDir)) {
+            throw new WriteDirNotAbsoluteException($writeDir);
         }
 
         $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -16,6 +16,7 @@ use function is_dir;
 use function mkdir;
 use function rtrim;
 use function sprintf;
+use function str_replace;
 
 /**
  * @psalm-import-type AppName from Types
@@ -23,6 +24,7 @@ use function sprintf;
  * @psalm-import-type AppDir from Types
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
+ * @psalm-import-type WriteDir from Types
  */
 final class Meta extends AbstractAppMeta
 {
@@ -41,9 +43,32 @@ final class Meta extends AbstractAppMeta
         string|null $logDir = null,
     ) {
         $this->name = $name;
-        $this->appDir = $appDir !== '' ? $appDir : $this->getAppDir($name);
-        $this->tmpDir = $this->ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
-        $this->logDir = $this->ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
+        $this->appDir = $appDir !== '' ? $appDir : self::appDir($name);
+        $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
+        $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
+    }
+
+    /**
+     * Meta writing under {writeDir}/{Vendor}/{Project}/{context}, or its own var/ when null.
+     *
+     * A boot must pass what the compile passed: differ on any argument and they read different files.
+     *
+     * @param AppName       $name
+     * @param Context       $context
+     * @param AppDir        $appDir
+     * @param WriteDir|null $writeDir absolute base outside the application directory
+     */
+    public static function create(string $name, string $context, string $appDir, string|null $writeDir): self
+    {
+        if ($writeDir === null) {
+            return new self($name, $context, $appDir);
+        }
+
+        $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;
+        $meta = new self($name, $context, $appDir, $base . '/tmp', $base . '/log');
+        $meta->writeDir = $writeDir;
+
+        return $meta;
     }
 
     /**
@@ -51,7 +76,7 @@ final class Meta extends AbstractAppMeta
      *
      * @return non-empty-string
      */
-    private function ensureDir(string $dir): string
+    private static function ensureDir(string $dir): string
     {
         $dir = rtrim($dir, '/\\');
         assert($dir !== '');
@@ -63,11 +88,15 @@ final class Meta extends AbstractAppMeta
     }
 
     /**
+     * The directory of an application, resolved from its AppModule.
+     *
      * @param AppName $name
      *
      * @return AppDir
+     *
+     * @throws AppNameException
      */
-    private function getAppDir(string $name): string
+    public static function appDir(string $name): string
     {
         $module = $name . '\Module\AppModule';
         if (! class_exists($module)) {

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -55,10 +55,10 @@ final class Meta extends AbstractAppMeta
      *
      * A boot must pass what the compile passed: differ on any argument and they read different files.
      *
-     * @param AppName       $name
-     * @param Context       $context
-     * @param AppDir        $appDir
-     * @param WriteDir|null $writeDir absolute base outside the application directory
+     * @param AppName     $name
+     * @param Context     $context
+     * @param AppDir      $appDir
+     * @param string|null $writeDir absolute base outside the application directory, checked here
      *
      * @throws WriteDirNotAbsoluteException
      */
@@ -72,6 +72,8 @@ final class Meta extends AbstractAppMeta
         if (! preg_match('#^(/|\\\\\\\\|[A-Za-z]:[/\\\\]|[A-Za-z][A-Za-z0-9+.\-]*://)#', $writeDir)) {
             throw new WriteDirNotAbsoluteException($writeDir);
         }
+
+        assert($writeDir !== '');
 
         $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;
         $meta = new self($name, $context, $appDir, $base . '/tmp', $base . '/log');

--- a/src/Types.php
+++ b/src/Types.php
@@ -15,6 +15,7 @@ namespace BEAR\AppMeta;
  * @psalm-type AppDir = non-empty-string
  * @psalm-type TmpDir = non-empty-string
  * @psalm-type LogDir = non-empty-string
+ * @psalm-type WriteDir = non-empty-string
  * @psalm-type UriPath = non-empty-string
  * @psalm-type FilePath = non-empty-string
  * @psalm-type Scheme = 'app'|'page'|'*'

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\AppMeta;
 
+use BEAR\AppMeta\Exception\AppNameException;
 use FakeVendor\HelloWorld\Resource\App\One;
 use FakeVendor\HelloWorld\Resource\App\Sub\Sub\Four;
 use FakeVendor\HelloWorld\Resource\App\Sub\Three;
@@ -96,6 +97,41 @@ class MetaTest extends TestCase
         $this->assertSame($this->normalizePath($logDir), $this->normalizePath($meta->logDir));
         $this->assertDirectoryExists($meta->tmpDir);
         $this->assertDirectoryExists($meta->logDir);
+    }
+
+    public function testCreateWritesUnderTheGivenBase(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
+        $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), $base);
+        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $this->normalizePath($meta->tmpDir));
+        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/log'), $this->normalizePath($meta->logDir));
+        $this->assertDirectoryExists($meta->tmpDir);
+        $this->assertDirectoryExists($meta->logDir);
+    }
+
+    public function testCreateCarriesTheBaseItWasGiven(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $this->assertSame($base, Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, $base)->writeDir);
+        $this->assertNull(Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, null)->writeDir);
+    }
+
+    public function testCreateWithoutBaseWritesInItsOwnVar(): void
+    {
+        $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), null);
+        $this->assertSame($this->normalizePath($meta->appDir . '/var/tmp/prod-app'), $this->normalizePath($meta->tmpDir));
+    }
+
+    public function testAppDirResolvesFromTheAppModule(): void
+    {
+        $this->assertSame($this->meta->appDir, Meta::appDir('FakeVendor\\HelloWorld'));
+    }
+
+    public function testAppDirRefusesAnAppItCannotLocate(): void
+    {
+        $this->expectException(AppNameException::class);
+        Meta::appDir('No\\Such\\App');
     }
 
     private function normalizePath(string $path): string

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\AppMeta;
 
 use BEAR\AppMeta\Exception\AppNameException;
+use BEAR\AppMeta\Exception\WriteDirNotAbsoluteException;
 use FakeVendor\HelloWorld\Resource\App\One;
 use FakeVendor\HelloWorld\Resource\App\Sub\Sub\Four;
 use FakeVendor\HelloWorld\Resource\App\Sub\Three;
@@ -121,6 +122,19 @@ class MetaTest extends TestCase
     {
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), null);
         $this->assertSame($this->normalizePath($meta->appDir . '/var/tmp/prod-app'), $this->normalizePath($meta->tmpDir));
+    }
+
+    /** @dataProvider baseThatTheCurrentDirectoryResolves */
+    public function testCreateRefusesABaseThatIsNotAbsolute(string $base): void
+    {
+        $this->expectException(WriteDirNotAbsoluteException::class);
+        Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), $base);
+    }
+
+    /** @return array<string, array{0: string}> */
+    public static function baseThatTheCurrentDirectoryResolves(): array
+    {
+        return ['empty' => [''], 'relative' => ['var/write'], 'dot' => ['./write']];
     }
 
     public function testAppDirResolvesFromTheAppModule(): void


### PR DESCRIPTION
`Meta::create($name, $context, $appDir, $writeDir)` places an application under `{writeDir}/{Vendor}/{Project}/{context}`, or its own `var/` when `$writeDir` is null, and carries the base in `$writeDir`.

`Meta::appDir($name)` resolves an application directory from its name.

Additive: no existing behaviour changes.

Needed by [BEAR.Package#495](https://github.com/bearsunday/BEAR.Package/pull/495) ([#426](https://github.com/bearsunday/BEAR.Package/issues/426)), which carries this layout in its own class today.
