### PR TITLE
Publish the build directory on AppMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
+- `Meta::buildDir($appDir, $context)`: the rule behind `$buildDir` without side effects, for a caller that reads a directory it never boots
 
 ### Deprecated
 - `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it, gone in the next minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
-- `Meta::buildDir($appDir, $context)`: the rule behind `$buildDir` without side effects, for a caller that reads a directory it never boots
 
 ### Deprecated
 - `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it, gone in the next minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
+- `AbstractAppMeta::__wakeup()` re-points paths under `appDir` when the application has moved since serialization
+- `Meta` refuses a relative `$tmpDir`/`$logDir` with `WriteDirNotAbsoluteException`
+
+### Changed
+- `Meta::appDir($name)` moved to `AbstractAppMeta` and returns the canonical spelling, as do `$appDir`, `$tmpDir` and `$logDir`
+- Canonical spellings make existing compile markers mismatch once: recompile when deploying this release (a writable tree recompiles on first boot; a read-only tree must be rebuilt)
 
 ### Deprecated
 - `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it, gone in the next minor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
+
 ## [1.12.0] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
 - `AbstractAppMeta::__wakeup()` re-points paths under `appDir` when the application has moved since serialization
-- `Meta` refuses a relative `$tmpDir`/`$logDir` with `WriteDirNotAbsoluteException`
+- `Meta` refuses a relative `$appDir`, `$tmpDir` or `$logDir` with `WriteDirNotAbsoluteException`
 
 ### Changed
 - `Meta::appDir($name)` moved to `AbstractAppMeta` and returns the canonical spelling, as do `$appDir`, `$tmpDir` and `$logDir`
 - Canonical spellings make existing compile markers mismatch once: recompile when deploying this release (a writable tree recompiles on first boot; a read-only tree must be rebuilt)
 
 ### Deprecated
-- `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it, gone in the next minor
+- `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it; removal is a BC break and waits for the next major
 
 ## [1.12.0] - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `$buildDir` on `AbstractAppMeta`: `{appDir}/var/build/{context}`, fixed to `appDir` regardless of `$writeDir` and not created
 
+### Deprecated
+- `$writeDir` on `AbstractAppMeta`: still filled for released `bear/package` versions that read it, gone in the next minor
+
 ## [1.12.0] - 2026-08-16
 
 ### Added

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -26,6 +26,7 @@ use const DIRECTORY_SEPARATOR;
  * @psalm-import-type AppDir from Types
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
+ * @psalm-import-type BuildDir from Types
  * @psalm-import-type WriteDir from Types
  * @psalm-import-type UriPath from Types
  * @psalm-import-type FilePath from Types
@@ -48,6 +49,15 @@ abstract class AbstractAppMeta
 
     /** @var LogDir */
     public string $logDir;
+
+    /**
+     * Where a compile puts what it produced, {appDir}/var/build/{context}
+     *
+     * Fixed to appDir even when $writeDir is set, and not created here: a build ships inside the application, which may be read-only or a phar.
+     *
+     * @var BuildDir
+     */
+    public string $buildDir;
 
     /**
      * The base directory this application was placed under, null when it was not placed under one

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -51,9 +51,7 @@ abstract class AbstractAppMeta
     public string $logDir;
 
     /**
-     * Where a compile puts what it produced, {appDir}/var/build/{context}
-     *
-     * Fixed to appDir even when $writeDir is set, and not created here: a build ships inside the application, which may be read-only or a phar.
+     * Artifacts derived from the source
      *
      * @var BuildDir
      */

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -61,6 +61,12 @@ abstract class AbstractAppMeta
      */
     public string $buildDir;
 
+    /**
+     * @var WriteDir|null
+     * @deprecated Do not use.
+     */
+    public string|null $writeDir = null;
+
     /** @return Generator<array{0: class-string<ResourceObject>, 1: FilePath}> */
     public function getResourceListGenerator(): Generator
     {

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -61,13 +61,6 @@ abstract class AbstractAppMeta
      */
     public string $buildDir;
 
-    /**
-     * The base directory this application was placed under, null when it was not placed under one
-     *
-     * @var WriteDir|null
-     */
-    public string|null $writeDir = null;
-
     /** @return Generator<array{0: class-string<ResourceObject>, 1: FilePath}> */
     public function getResourceListGenerator(): Generator
     {

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -44,7 +44,11 @@ abstract class AbstractAppMeta
     /** @var AppDir */
     public string $appDir;
 
-    /** @var TmpDir */
+    /**
+     * Data derived at runtime
+     *
+     * @var TmpDir
+     */
     public string $tmpDir;
 
     /** @var LogDir */

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -85,9 +85,9 @@ abstract class AbstractAppMeta
      */
     public function __wakeup(): void
     {
-        $appDir = self::appDir($this->name);
         $from = str_replace('\\', '/', $this->appDir);
-        $to = str_replace('\\', '/', $appDir);
+        /** @var AppDir $to rebased paths spell forward-slashed, whatever the platform */
+        $to = str_replace('\\', '/', self::appDir($this->name));
         if ($from === $to) {
             return;
         }
@@ -105,7 +105,7 @@ abstract class AbstractAppMeta
             }
         }
 
-        $this->appDir = $appDir;
+        $this->appDir = $to;
     }
 
     /**

--- a/src/AbstractAppMeta.php
+++ b/src/AbstractAppMeta.php
@@ -4,20 +4,29 @@ declare(strict_types=1);
 
 namespace BEAR\AppMeta;
 
+use BEAR\AppMeta\Exception\AppNameException;
 use BEAR\Resource\ResourceObject;
 use Generator;
 use Koriym\Psr4List\Psr4List;
+use ReflectionClass;
 
 use function array_slice;
 use function array_walk;
 use function assert;
+use function class_exists;
+use function dirname;
 use function explode;
 use function implode;
 use function is_a;
 use function ltrim;
 use function preg_replace;
+use function realpath;
 use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
 use function strtolower;
+use function substr;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -66,6 +75,66 @@ abstract class AbstractAppMeta
      * @deprecated Do not use.
      */
     public string|null $writeDir = null;
+
+    /**
+     * Re-point the paths under the application directory when it has moved or changed spelling.
+     *
+     * A serialized Meta was made on the build machine. Only paths below appDir go stale
+     * when the tree or archive moves; the rest (a writeDir base, a name-derived rule)
+     * is move-invariant by contract and left untouched.
+     */
+    public function __wakeup(): void
+    {
+        $appDir = self::appDir($this->name);
+        $from = str_replace('\\', '/', $this->appDir);
+        $to = str_replace('\\', '/', $appDir);
+        if ($from === $to) {
+            return;
+        }
+
+        foreach (['tmpDir', 'logDir', 'buildDir'] as $dir) {
+            /** @var string|null $path null only for 1.12 payloads, which carry no buildDir */
+            $path = $this->$dir ?? null;
+            if ($path === null) {
+                continue;
+            }
+
+            $path = str_replace('\\', '/', $path);
+            if (str_starts_with($path, $from . '/')) {
+                $this->$dir = $to . substr($path, strlen($from));
+            }
+        }
+
+        $this->appDir = $appDir;
+    }
+
+    /**
+     * The directory of an application, resolved from its AppModule.
+     *
+     * @param AppName $name
+     *
+     * @return AppDir the canonical spelling
+     *
+     * @throws AppNameException
+     */
+    public static function appDir(string $name): string
+    {
+        $module = $name . '\Module\AppModule';
+        if (! class_exists($module)) {
+            throw new AppNameException($name);
+        }
+
+        $fileName = (new ReflectionClass($module))->getFileName();
+        assert($fileName !== false, sprintf('Cannot locate AppModule file: %s', $module));
+
+        $dir = dirname($fileName, 3);
+        $real = realpath($dir);
+
+        /** @var AppDir $canonical */
+        $canonical = $real === false ? $dir : $real;
+
+        return $canonical;
+    }
 
     /** @return Generator<array{0: class-string<ResourceObject>, 1: FilePath}> */
     public function getResourceListGenerator(): Generator

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -40,7 +40,10 @@ final class Meta extends AbstractAppMeta
         string|null $logDir = null,
     ) {
         $this->name = $name;
-        $this->appDir = self::normalize($appDir !== '' ? $appDir : self::appDir($name));
+        $appDir = $appDir !== '' ? $appDir : self::appDir($name);
+        // @phpstan-ignore staticMethod.alreadyNarrowedType (the regex check runs at runtime regardless of the type)
+        self::assertAbsolute($appDir);
+        $this->appDir = self::normalize($appDir);
         $this->buildDir = $this->appDir . '/var/build/' . $context;
         $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -4,20 +4,15 @@ declare(strict_types=1);
 
 namespace BEAR\AppMeta;
 
-use BEAR\AppMeta\Exception\AppNameException;
 use BEAR\AppMeta\Exception\NotWritableException;
 use BEAR\AppMeta\Exception\WriteDirNotAbsoluteException;
-use ReflectionClass;
 
-use function assert;
-use function class_exists;
-use function dirname;
 use function file_exists;
 use function is_dir;
 use function mkdir;
 use function preg_match;
+use function realpath;
 use function rtrim;
-use function sprintf;
 use function str_replace;
 
 /**
@@ -45,7 +40,7 @@ final class Meta extends AbstractAppMeta
         string|null $logDir = null,
     ) {
         $this->name = $name;
-        $this->appDir = $appDir !== '' ? $appDir : self::appDir($name);
+        $this->appDir = self::normalize($appDir !== '' ? $appDir : self::appDir($name));
         $this->buildDir = $this->appDir . '/var/build/' . $context;
         $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
@@ -70,11 +65,7 @@ final class Meta extends AbstractAppMeta
         }
 
         // A base the current directory resolves lands somewhere else on the next run
-        if (! preg_match('#^(/|\\\\\\\\|[A-Za-z]:[/\\\\]|[A-Za-z][A-Za-z0-9+.\-]*://)#', $writeDir)) {
-            throw new WriteDirNotAbsoluteException($writeDir);
-        }
-
-        assert($writeDir !== '');
+        self::assertAbsolute($writeDir);
 
         $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;
         $meta = new self($name, $context, $appDir, $base . '/tmp', $base . '/log');
@@ -87,42 +78,40 @@ final class Meta extends AbstractAppMeta
     /**
      * @param non-empty-string $dir
      *
-     * @return non-empty-string
+     * @return non-empty-string the canonical spelling: one directory, one string
      */
     private static function ensureDir(string $dir): string
     {
         $dir = rtrim($dir, '/\\');
-        assert($dir !== '');
+        self::assertAbsolute($dir);
         if (! file_exists($dir) && ! @mkdir($dir, 0777, true) && ! is_dir($dir)) {
             throw new NotWritableException($dir);
         }
 
-        return $dir;
+        return self::normalize($dir);
+    }
+
+    /** @psalm-assert non-empty-string $dir */
+    private static function assertAbsolute(string $dir): void
+    {
+        if (! preg_match('#^(/|\\\\\\\\|[A-Za-z]:[/\\\\]|[A-Za-z][A-Za-z0-9+.\-]*://)#', $dir)) {
+            throw new WriteDirNotAbsoluteException($dir);
+        }
     }
 
     /**
-     * The directory of an application, resolved from its AppModule.
+     * @param non-empty-string $dir
      *
-     * @param AppName $name
-     *
-     * @return AppDir
-     *
-     * @throws AppNameException
+     * @return non-empty-string
      */
-    public static function appDir(string $name): string
+    private static function normalize(string $dir): string
     {
-        $module = $name . '\Module\AppModule';
-        if (! class_exists($module)) {
-            throw new AppNameException($name);
+        $real = realpath($dir);
+        if ($real === false) {
+            return $dir;
         }
 
-        $fileName = (new ReflectionClass($module))->getFileName();
-        assert($fileName !== false, sprintf('Cannot locate AppModule file: %s', $module));
-
-        /** @var AppDir $dir */
-        $dir = dirname($fileName, 3);
-        assert($dir !== '.');
-
-        return $dir;
+        /** @var non-empty-string $real */
+        return $real;
     }
 }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -78,7 +78,6 @@ final class Meta extends AbstractAppMeta
 
         $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;
         $meta = new self($name, $context, $appDir, $base . '/tmp', $base . '/log');
-        $meta->writeDir = $writeDir;
 
         return $meta;
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -78,6 +78,8 @@ final class Meta extends AbstractAppMeta
 
         $base = rtrim($writeDir, '/\\') . '/' . str_replace('\\', '/', $name) . '/' . $context;
         $meta = new self($name, $context, $appDir, $base . '/tmp', $base . '/log');
+        /** @psalm-suppress DeprecatedProperty the factory still fills what releases read */
+        $meta->writeDir = $writeDir;
 
         return $meta;
     }

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -27,7 +27,6 @@ use function str_replace;
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
  * @psalm-import-type WriteDir from Types
- * @psalm-import-type BuildDir from Types
  */
 final class Meta extends AbstractAppMeta
 {
@@ -47,26 +46,9 @@ final class Meta extends AbstractAppMeta
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : self::appDir($name);
-        $this->buildDir = self::buildDir($this->appDir, $context);
+        $this->buildDir = $this->appDir . '/var/build/' . $context;
         $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
-    }
-
-    /**
-     * Where a compile of $context puts what it produced.
-     *
-     * The rule behind `$buildDir`, for a caller holding no Meta: a pack reads the directories of
-     * applications it never boots, and a Meta of each would create their tmp and log inside the
-     * tree being packed.
-     *
-     * @param AppDir  $appDir
-     * @param Context $context
-     *
-     * @return BuildDir
-     */
-    public static function buildDir(string $appDir, string $context): string
-    {
-        return $appDir . '/var/build/' . $context;
     }
 
     /**

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -27,6 +27,7 @@ use function str_replace;
  * @psalm-import-type TmpDir from Types
  * @psalm-import-type LogDir from Types
  * @psalm-import-type WriteDir from Types
+ * @psalm-import-type BuildDir from Types
  */
 final class Meta extends AbstractAppMeta
 {
@@ -46,9 +47,26 @@ final class Meta extends AbstractAppMeta
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : self::appDir($name);
-        $this->buildDir = $this->appDir . '/var/build/' . $context;
+        $this->buildDir = self::buildDir($this->appDir, $context);
         $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
+    }
+
+    /**
+     * Where a compile of $context puts what it produced.
+     *
+     * The rule behind `$buildDir`, for a caller holding no Meta: a pack reads the directories of
+     * applications it never boots, and a Meta of each would create their tmp and log inside the
+     * tree being packed.
+     *
+     * @param AppDir  $appDir
+     * @param Context $context
+     *
+     * @return BuildDir
+     */
+    public static function buildDir(string $appDir, string $context): string
+    {
+        return $appDir . '/var/build/' . $context;
     }
 
     /**

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -46,6 +46,7 @@ final class Meta extends AbstractAppMeta
     ) {
         $this->name = $name;
         $this->appDir = $appDir !== '' ? $appDir : self::appDir($name);
+        $this->buildDir = $this->appDir . '/var/build/' . $context;
         $this->tmpDir = self::ensureDir($tmpDir ?? $this->appDir . '/var/tmp/' . $context);
         $this->logDir = self::ensureDir($logDir ?? $this->appDir . '/var/log/' . $context);
     }

--- a/src/Types.php
+++ b/src/Types.php
@@ -15,6 +15,7 @@ namespace BEAR\AppMeta;
  * @psalm-type AppDir = non-empty-string
  * @psalm-type TmpDir = non-empty-string
  * @psalm-type LogDir = non-empty-string
+ * @psalm-type BuildDir = non-empty-string
  * @psalm-type WriteDir = non-empty-string
  * @psalm-type UriPath = non-empty-string
  * @psalm-type FilePath = non-empty-string

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -14,14 +14,18 @@ use FakeVendor\HelloWorld\Resource\App\User;
 use FakeVendor\HelloWorld\Resource\Page\Index;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
 use function chmod;
 use function dirname;
 use function file_put_contents;
 use function mkdir;
+use function realpath;
+use function serialize;
 use function sort;
 use function str_replace;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_OS_FAMILY;
@@ -97,8 +101,8 @@ class MetaTest extends TestCase
         $tmpDir = $base . DIRECTORY_SEPARATOR . 'tmp';
         $logDir = $base . DIRECTORY_SEPARATOR . 'log';
         $meta = new Meta('FakeVendor\HelloWorld', 'prod-app', '', $tmpDir, $logDir);
-        $this->assertSame($this->normalizePath($tmpDir), $this->normalizePath($meta->tmpDir));
-        $this->assertSame($this->normalizePath($logDir), $this->normalizePath($meta->logDir));
+        $this->assertSame(realpath($tmpDir), $meta->tmpDir);
+        $this->assertSame(realpath($logDir), $meta->logDir);
         $this->assertDirectoryExists($meta->tmpDir);
         $this->assertDirectoryExists($meta->logDir);
     }
@@ -107,8 +111,8 @@ class MetaTest extends TestCase
     {
         $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), $base);
-        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $this->normalizePath($meta->tmpDir));
-        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/log'), $this->normalizePath($meta->logDir));
+        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
+        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/log', $meta->logDir);
         $this->assertDirectoryExists($meta->tmpDir);
         $this->assertDirectoryExists($meta->logDir);
     }
@@ -138,7 +142,7 @@ class MetaTest extends TestCase
         $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
         $appDir = Meta::appDir('FakeVendor\\HelloWorld');
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, $base);
-        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $this->normalizePath($meta->tmpDir));
+        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
         $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
     }
 
@@ -170,7 +174,7 @@ class MetaTest extends TestCase
 
         try {
             $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid());
-            $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
+            $this->assertSame($meta->appDir . '/var/build/prod-app', $meta->buildDir);
             $this->assertDirectoryDoesNotExist($meta->buildDir);
         } finally {
             chmod($appDir, 0777);
@@ -189,6 +193,66 @@ class MetaTest extends TestCase
     public static function baseThatTheCurrentDirectoryResolves(): array
     {
         return ['empty' => [''], 'relative' => ['var/write'], 'dot' => ['./write']];
+    }
+
+    public function testUnserializeRelocatesPathsUnderTheAppDir(): void
+    {
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app');
+        // spellings from a build machine the application has left since
+        $meta->appDir = '/build/machine/app';
+        $meta->tmpDir = '/build/machine/app/var/tmp/prod-app';
+        $meta->logDir = '/build/machine/app/var/log/prod-app';
+        $meta->buildDir = '/build/machine/app/var/build/prod-app';
+
+        $woke = unserialize(serialize($meta));
+        assert($woke instanceof Meta);
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $this->assertSame($appDir, $woke->appDir);
+        $this->assertSame($appDir . '/var/tmp/prod-app', $woke->tmpDir);
+        $this->assertSame($appDir . '/var/log/prod-app', $woke->logDir);
+        $this->assertSame($appDir . '/var/build/prod-app', $woke->buildDir);
+    }
+
+    public function testWakeupKeepsPathsOutsideTheAppDir(): void
+    {
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app');
+        $meta->appDir = '/build/machine/app';
+        $meta->tmpDir = '/write/FakeVendor/HelloWorld/prod-app/tmp'; // writeDir-derived: move-invariant
+        $meta->logDir = '/logs/FakeVendor/HelloWorld'; // a custom rule: move-invariant
+        $meta->buildDir = '/build/machine/app/var/build/prod-app';
+
+        $meta->__wakeup();
+        $this->assertSame(Meta::appDir('FakeVendor\\HelloWorld'), $meta->appDir);
+        $this->assertSame('/write/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
+        $this->assertSame('/logs/FakeVendor/HelloWorld', $meta->logDir);
+        $this->assertSame(Meta::appDir('FakeVendor\\HelloWorld') . '/var/build/prod-app', $meta->buildDir);
+    }
+
+    public function testWakeupIsQuietWhenTheApplicationHasNotMoved(): void
+    {
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app');
+        $before = [$meta->appDir, $meta->tmpDir, $meta->logDir, $meta->buildDir];
+        $meta->__wakeup();
+        $this->assertSame($before, [$meta->appDir, $meta->tmpDir, $meta->logDir, $meta->buildDir]);
+    }
+
+    public function testTmpAndLogDirComeInOneSpelling(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-app-meta-' . uniqid();
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app', '', $base . '/tmp', $base . '/log');
+        $this->assertSame(realpath($meta->tmpDir), $meta->tmpDir);
+        $this->assertSame(realpath($meta->logDir), $meta->logDir);
+    }
+
+    /**
+     * @dataProvider baseThatTheCurrentDirectoryResolves
+     * @psalm-suppress InvalidArgument the point is passing an unusable dir
+     */
+    public function testRefusesATmpDirThatIsNotAbsolute(string $tmpDir): void
+    {
+        $this->expectException(WriteDirNotAbsoluteException::class);
+        // @phpstan-ignore argument.type (the point is passing an unusable dir)
+        new Meta('FakeVendor\\HelloWorld', 'prod-app', '', $tmpDir);
     }
 
     public function testAppDirResolvesFromTheAppModule(): void

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -111,8 +111,8 @@ class MetaTest extends TestCase
     {
         $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), $base);
-        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
-        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/log', $meta->logDir);
+        $this->assertSame(realpath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $meta->tmpDir);
+        $this->assertSame(realpath($base . '/FakeVendor/HelloWorld/prod-app/log'), $meta->logDir);
         $this->assertDirectoryExists($meta->tmpDir);
         $this->assertDirectoryExists($meta->logDir);
     }
@@ -142,7 +142,7 @@ class MetaTest extends TestCase
         $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
         $appDir = Meta::appDir('FakeVendor\\HelloWorld');
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, $base);
-        $this->assertSame(realpath($base) . '/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
+        $this->assertSame(realpath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $meta->tmpDir);
         $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
     }
 
@@ -207,10 +207,10 @@ class MetaTest extends TestCase
         $woke = unserialize(serialize($meta));
         assert($woke instanceof Meta);
         $appDir = Meta::appDir('FakeVendor\\HelloWorld');
-        $this->assertSame($appDir, $woke->appDir);
-        $this->assertSame($appDir . '/var/tmp/prod-app', $woke->tmpDir);
-        $this->assertSame($appDir . '/var/log/prod-app', $woke->logDir);
-        $this->assertSame($appDir . '/var/build/prod-app', $woke->buildDir);
+        $this->assertSame($this->normalizePath($appDir), $this->normalizePath($woke->appDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/tmp/prod-app'), $this->normalizePath($woke->tmpDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/log/prod-app'), $this->normalizePath($woke->logDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($woke->buildDir));
     }
 
     public function testWakeupKeepsPathsOutsideTheAppDir(): void
@@ -222,10 +222,11 @@ class MetaTest extends TestCase
         $meta->buildDir = '/build/machine/app/var/build/prod-app';
 
         $meta->__wakeup();
-        $this->assertSame(Meta::appDir('FakeVendor\\HelloWorld'), $meta->appDir);
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $this->assertSame($this->normalizePath($appDir), $this->normalizePath($meta->appDir));
         $this->assertSame('/write/FakeVendor/HelloWorld/prod-app/tmp', $meta->tmpDir);
         $this->assertSame('/logs/FakeVendor/HelloWorld', $meta->logDir);
-        $this->assertSame(Meta::appDir('FakeVendor\\HelloWorld') . '/var/build/prod-app', $meta->buildDir);
+        $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
     }
 
     public function testWakeupIsQuietWhenTheApplicationHasNotMoved(): void

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -157,16 +157,6 @@ class MetaTest extends TestCase
         $this->assertDirectoryDoesNotExist($meta->buildDir);
     }
 
-    /** The rule a pack applies without a Meta has to be the rule a Meta applies. */
-    public function testBuildDirStaticAnswersWhatAnInstanceHolds(): void
-    {
-        $appDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-build-static-' . uniqid();
-        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app', $appDir);
-
-        $this->assertSame($this->normalizePath($meta->buildDir), $this->normalizePath(Meta::buildDir($appDir, 'prod-app')));
-        $this->assertDirectoryDoesNotExist(Meta::buildDir($appDir, 'stage-app'));
-    }
-
     public function testMetaIsBuiltForAnApplicationItCannotWriteTo(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -14,14 +14,17 @@ use FakeVendor\HelloWorld\Resource\App\User;
 use FakeVendor\HelloWorld\Resource\Page\Index;
 use PHPUnit\Framework\TestCase;
 
+use function chmod;
 use function dirname;
 use function file_put_contents;
+use function mkdir;
 use function sort;
 use function str_replace;
 use function sys_get_temp_dir;
 use function uniqid;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_OS_FAMILY;
 
 class MetaTest extends TestCase
 {
@@ -122,6 +125,57 @@ class MetaTest extends TestCase
     {
         $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', Meta::appDir('FakeVendor\\HelloWorld'), null);
         $this->assertSame($this->normalizePath($meta->appDir . '/var/tmp/prod-app'), $this->normalizePath($meta->tmpDir));
+    }
+
+    public function testBuildDirIsUnderTheApplication(): void
+    {
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app');
+        $this->assertSame($this->normalizePath($meta->appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
+    }
+
+    public function testBuildDirStaysUnderTheApplicationWhenTmpAndLogFollowTheBase(): void
+    {
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid();
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, $base);
+        $this->assertSame($this->normalizePath($base . '/FakeVendor/HelloWorld/prod-app/tmp'), $this->normalizePath($meta->tmpDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
+    }
+
+    public function testBuildDirSeparatesContexts(): void
+    {
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath((new Meta('FakeVendor\\HelloWorld', 'prod-app'))->buildDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/build/stage-app'), $this->normalizePath((new Meta('FakeVendor\\HelloWorld', 'stage-app'))->buildDir));
+    }
+
+    public function testBuildDirIsNotCreated(): void
+    {
+        $appDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-build-dir-' . uniqid();
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app', $appDir);
+        $this->assertDirectoryExists($meta->tmpDir);
+        $this->assertDirectoryDoesNotExist($meta->buildDir);
+    }
+
+    public function testMetaIsBuiltForAnApplicationItCannotWriteTo(): void
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->markTestSkipped('chmod does not write-protect a directory on Windows.');
+        }
+
+        $appDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-read-only-' . uniqid();
+        mkdir($appDir . '/var', 0777, true);
+        chmod($appDir . '/var', 0555);
+        chmod($appDir, 0555);
+
+        try {
+            $meta = Meta::create('FakeVendor\\HelloWorld', 'prod-app', $appDir, sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-write-dir-' . uniqid());
+            $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($meta->buildDir));
+            $this->assertDirectoryDoesNotExist($meta->buildDir);
+        } finally {
+            chmod($appDir, 0777);
+            chmod($appDir . '/var', 0777);
+        }
     }
 
     /** @dataProvider baseThatTheCurrentDirectoryResolves */

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -265,6 +265,12 @@ class MetaTest extends TestCase
         $this->assertSame(realpath($meta->logDir), $meta->logDir);
     }
 
+    public function testRefusesAnAppDirThatIsNotAbsolute(): void
+    {
+        $this->expectException(WriteDirNotAbsoluteException::class);
+        new Meta('FakeVendor\\HelloWorld', 'prod-app', 'relative/app', sys_get_temp_dir() . '/bear-tmp-' . uniqid(), sys_get_temp_dir() . '/bear-log-' . uniqid());
+    }
+
     /**
      * @dataProvider baseThatTheCurrentDirectoryResolves
      * @psalm-suppress InvalidArgument the point is passing an unusable dir

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -157,6 +157,16 @@ class MetaTest extends TestCase
         $this->assertDirectoryDoesNotExist($meta->buildDir);
     }
 
+    /** The rule a pack applies without a Meta has to be the rule a Meta applies. */
+    public function testBuildDirStaticAnswersWhatAnInstanceHolds(): void
+    {
+        $appDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'bear-build-static-' . uniqid();
+        $meta = new Meta('FakeVendor\\HelloWorld', 'prod-app', $appDir);
+
+        $this->assertSame($this->normalizePath($meta->buildDir), $this->normalizePath(Meta::buildDir($appDir, 'prod-app')));
+        $this->assertDirectoryDoesNotExist(Meta::buildDir($appDir, 'stage-app'));
+    }
+
     public function testMetaIsBuiltForAnApplicationItCannotWriteTo(): void
     {
         if (PHP_OS_FAMILY === 'Windows') {

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -22,7 +22,9 @@ use function mkdir;
 use function realpath;
 use function serialize;
 use function sort;
+use function sprintf;
 use function str_replace;
+use function strlen;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unserialize;
@@ -211,6 +213,24 @@ class MetaTest extends TestCase
         $this->assertSame($this->normalizePath($appDir . '/var/tmp/prod-app'), $this->normalizePath($woke->tmpDir));
         $this->assertSame($this->normalizePath($appDir . '/var/log/prod-app'), $this->normalizePath($woke->logDir));
         $this->assertSame($this->normalizePath($appDir . '/var/build/prod-app'), $this->normalizePath($woke->buildDir));
+    }
+
+    public function testUnserializeAcceptsAPayloadWithoutBuildDir(): void
+    {
+        // what 1.12 baked: five fields, no buildDir
+        $field = static fn (string $key, string $value): string => sprintf('s:%d:"%s";s:%d:"%s";', strlen($key), $key, strlen($value), $value);
+        $payload = 'O:17:"BEAR\\AppMeta\\Meta":5:{'
+            . $field('name', 'FakeVendor\\HelloWorld')
+            . $field('appDir', '/build/machine/app')
+            . $field('tmpDir', '/build/machine/app/var/tmp/prod-app')
+            . $field('logDir', '/build/machine/app/var/log/prod-app')
+            . 's:8:"writeDir";N;}';
+
+        $woke = unserialize($payload);
+        assert($woke instanceof Meta);
+        $appDir = Meta::appDir('FakeVendor\\HelloWorld');
+        $this->assertSame($this->normalizePath($appDir . '/var/tmp/prod-app'), $this->normalizePath($woke->tmpDir));
+        $this->assertSame($this->normalizePath($appDir . '/var/log/prod-app'), $this->normalizePath($woke->logDir));
     }
 
     public function testWakeupKeepsPathsOutsideTheAppDir(): void


### PR DESCRIPTION
`$buildDir` is `{appDir}/var/build/{context}`: where a build phase writes artifacts that are read at serve time and never written then. It stays under `appDir` even when a write directory is passed, and it is the one directory `Meta` does not create.

This branch also makes a serialized `Meta` survive a move of the application tree or a phar archive:

- `AbstractAppMeta::__wakeup()` re-points paths under `appDir` by prefix replacement. Only those go stale on a move; a writeDir base or a name-derived rule is move-invariant and untouched, so custom `AbstractAppMeta` rules survive.
- `Meta::appDir()` moves to `AbstractAppMeta` (called the same way as before) and returns the canonical spelling, as do `$appDir`/`$tmpDir`/`$logDir` (realpath). Relative `$tmpDir`/`$logDir` are refused with `WriteDirNotAbsoluteException`.
- `$writeDir` becomes `@deprecated`, still filled for released bear/package versions that read it.

Note for upgrades: canonical spellings make existing compile markers mismatch once - recompile when deploying this release (a writable tree recompiles on first boot; a read-only tree must be rebuilt).